### PR TITLE
combination argument error and max-depth error for irreducibility test

### DIFF
--- a/Chapter01/MarkovChainMatrix.py
+++ b/Chapter01/MarkovChainMatrix.py
@@ -55,7 +55,7 @@ class MarkovChain(object):
             current_state = next_state
         return future_states
 
-    def is_accessible(self, i_state, f_state):
+    def is_accessible(self, i_state, f_state, check_up_to_depth=1000):
         """
         Check if state f_state is accessible from i_state.
 
@@ -67,19 +67,23 @@ class MarkovChain(object):
         f_state: str
             The state to which accessibility needs to be checked.
         """
+        counter = 0
         reachable_states = [self.index_dict[i_state]]
         for state in reachable_states:
+            if counter == check_up_to_depth:
+                break
             if state == self.index_dict[f_state]:
                 return True
             else:
                 reachable_states.extend(np.nonzero(self.transition_matrix[state, :])[0])
+            counter = counter + 1
         return False
 
     def is_irreducible(self):
         """
         Check if the Markov Chain is irreducible.
         """
-        for (i, j) in combinations(self.states, self.states):
+        for (i, j) in combinations(self.states, 2):
             if not self.is_accessible(i, j):
                 return False
         return True


### PR DESCRIPTION
1. This is the correction for the below test scenario in which if there is no path from A to D then code keep on looping and never ends.  So we should define some max-depth till when one should check the path. 
2. Also combinations has second argument int (i.e. number of elements in set i.e. 2)

def  checck_irreducible():
    transition_irreducible = [[0.5, 0.5, 0, 0],
                              [0.25, 0, 0.5, 0.25],
                              [0.25, 0.5, 0, 0.25],
                              [0, 0, 0.5, 0.5]]

    transition_reducible = [[0.5, 0.5, 0, 0],
                            [0, 1, 0, 0],
                            [0.25, 0.5, 0, 0],
                            [0, 0, 0.25, 0.75]]

    markov_irreducible = MarkovChain(
        transition_matrix=transition_irreducible,
        states=['A', 'B', 'C', 'D']
    )

    markov_reducible = MarkovChain(
        transition_matrix=transition_reducible,
        states=['A', 'B', 'C', 'D']
    )

    print(markov_irreducible.is_accessible(i_state='A', f_state='D'))
    print(markov_irreducible.is_accessible(i_state='B', f_state='D'))
    print (markov_irreducible.is_irreducible())

    print(markov_reducible.is_accessible(i_state='A', f_state='D'))
    print (markov_reducible.is_accessible(i_state='D', f_state='A'))
    print (markov_reducible.is_accessible(i_state='C', f_state='D'))
    print (markov_reducible.is_irreducible())


if __name__ == "__main__":
    checck_irreducible()